### PR TITLE
Country of order from zontab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- `ZoneTab.countriesForTimezone` now returns countries in the order declared in `zone1970.tab`, so the primary (most-populous) country is first. Earlier versions sorted alphabetically, which picked the wrong country for zones whose primary is not alphabetically first (e.g. `Pacific/Auckland` maps to `NZ,AQ` and should report NZ first, not AQ).
+
 ## 0.1.0
 
 - Added `ZoneTab` for offline country and IANA timezone lookup backed by `/usr/share/zoneinfo/zone1970.tab` (with a `zone.tab` fallback) and `iso3166.tab`. systemd-timedated does not expose country metadata over D-Bus, so this fills the gap for country-picker UIs.

--- a/lib/zone_tab.dart
+++ b/lib/zone_tab.dart
@@ -13,6 +13,7 @@ class ZoneTab {
 
   Map<String, String>? _countries;
   Map<String, List<String>>? _countryTimezones;
+  Map<String, List<String>>? _timezoneCountries;
 
   /// ISO 3166-1 alpha-2 code to human-readable country name.
   Future<Map<String, String>> getCountries() async {
@@ -42,7 +43,27 @@ class ZoneTab {
   /// falls back to `zone.tab`.
   Future<Map<String, List<String>>> getCountryTimezones() async {
     if (_countryTimezones != null) return _countryTimezones!;
+    await _parseZoneTab();
+    return _countryTimezones!;
+  }
 
+  /// Timezones for a single country code (case-insensitive). Returns an empty
+  /// list when the code is unknown.
+  Future<List<String>> timezonesForCountry(String countryCode) async {
+    final map = await getCountryTimezones();
+    return map[countryCode.toUpperCase()] ?? const <String>[];
+  }
+
+  /// ISO codes whose timezone list contains [timezone], preserving the order
+  /// declared in `zone1970.tab`: the primary country (most-populous) comes
+  /// first, with any secondary countries listed after in their original order.
+  /// Returns an empty list when the timezone is unknown.
+  Future<List<String>> countriesForTimezone(String timezone) async {
+    if (_timezoneCountries == null) await _parseZoneTab();
+    return _timezoneCountries![timezone] ?? const <String>[];
+  }
+
+  Future<void> _parseZoneTab() async {
     final zone1970 = File('$_zoneinfoDir/zone1970.tab');
     final zone = File('$_zoneinfoDir/zone.tab');
 
@@ -55,7 +76,9 @@ class ZoneTab {
       throw FileSystemException('tzdata not installed', zone1970.path);
     }
 
-    final result = <String, List<String>>{};
+    final countryToZones = <String, List<String>>{};
+    final zoneToCountries = <String, List<String>>{};
+
     for (final line in await source.readAsLines()) {
       if (line.isEmpty || line.startsWith('#')) continue;
       final parts = line.split('\t');
@@ -63,39 +86,25 @@ class ZoneTab {
       final codes = parts[0].split(',');
       final tz = parts[2].trim();
       if (tz.isEmpty) continue;
+      final orderedCodes = <String>[];
       for (final raw in codes) {
         final code = raw.trim().toUpperCase();
         if (code.isEmpty) continue;
-        (result[code] ??= <String>[]).add(tz);
+        (countryToZones[code] ??= <String>[]).add(tz);
+        orderedCodes.add(code);
       }
+      if (orderedCodes.isNotEmpty) zoneToCountries[tz] = orderedCodes;
     }
 
-    for (final list in result.values) {
+    for (final list in countryToZones.values) {
       list.sort();
     }
 
-    return _countryTimezones = Map<String, List<String>>.unmodifiable({
-      for (final entry in result.entries) entry.key: List<String>.unmodifiable(entry.value),
+    _countryTimezones = Map<String, List<String>>.unmodifiable({
+      for (final entry in countryToZones.entries) entry.key: List<String>.unmodifiable(entry.value),
     });
-  }
-
-  /// Timezones for a single country code (case-insensitive). Returns an empty
-  /// list when the code is unknown.
-  Future<List<String>> timezonesForCountry(String countryCode) async {
-    final map = await getCountryTimezones();
-    return map[countryCode.toUpperCase()] ?? const <String>[];
-  }
-
-  /// ISO codes whose timezone list contains [timezone]. Useful for
-  /// pre-selecting a country from the current system timezone. Returns an
-  /// empty list when the timezone is unknown.
-  Future<List<String>> countriesForTimezone(String timezone) async {
-    final map = await getCountryTimezones();
-    final matches = <String>[];
-    for (final entry in map.entries) {
-      if (entry.value.contains(timezone)) matches.add(entry.key);
-    }
-    matches.sort();
-    return matches;
+    _timezoneCountries = Map<String, List<String>>.unmodifiable({
+      for (final entry in zoneToCountries.entries) entry.key: List<String>.unmodifiable(entry.value),
+    });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dbus_datetime
 description: A Dart library for interacting with the systemd timedate1 D-Bus interface.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/akshaybabloo/dbus_datetime
 issue_tracker: https://github.com/akshaybabloo/dbus_datetime/issues
 

--- a/test/fixtures/zoneinfo/iso3166.tab
+++ b/test/fixtures/zoneinfo/iso3166.tab
@@ -2,6 +2,7 @@
 #
 #country-
 #code	name
+AQ	Antarctica
 CH	Switzerland
 DE	Germany
 LI	Liechtenstein

--- a/test/fixtures/zoneinfo/zone1970.tab
+++ b/test/fixtures/zoneinfo/zone1970.tab
@@ -5,7 +5,7 @@
 # 3. TZ
 # 4. Comment (optional)
 CH,DE,LI	+4723+00832	Europe/Zurich	Büsingen
-NZ	-3652+17446	Pacific/Auckland	most of NZ
+NZ,AQ	-3652+17446	Pacific/Auckland	most of NZ
 NZ	-4357-17633	Pacific/Chatham	Chatham Islands
 US	+404251-0740023	America/New_York	Eastern (most areas)
 US	+340308-1181434	America/Los_Angeles	Pacific

--- a/test/zone_tab_test.dart
+++ b/test/zone_tab_test.dart
@@ -16,7 +16,7 @@ void main() {
       expect(countries['NZ'], 'New Zealand');
       expect(countries['US'], 'United States');
       expect(countries['CH'], 'Switzerland');
-      expect(countries, hasLength(5));
+      expect(countries, hasLength(6));
     });
 
     test('getCountryTimezones maps single-zone country', () async {
@@ -51,11 +51,20 @@ void main() {
       expect(await zoneTab.timezonesForCountry('ZZ'), isEmpty);
     });
 
-    test('countriesForTimezone resolves shared zones', () async {
+    test('countriesForTimezone resolves shared zones in file order', () async {
       expect(await zoneTab.countriesForTimezone('Europe/Zurich'), [
         'CH',
         'DE',
         'LI',
+      ]);
+    });
+
+    test('countriesForTimezone preserves primary country even when not alpha-first', () async {
+      // Pacific/Auckland is "NZ,AQ" in the fixture — NZ is primary even though
+      // AQ is alphabetically earlier.
+      expect(await zoneTab.countriesForTimezone('Pacific/Auckland'), [
+        'NZ',
+        'AQ',
       ]);
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timezone country lookups to maintain the correct country ordering. Previously, countries were returned in alphabetical order, which could incorrectly position secondary countries before the primary. The primary/most-populous country is now correctly listed first.

* **Chores**
  * Package version bumped to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->